### PR TITLE
Agent can output markdown file of its results

### DIFF
--- a/packages/local/lib/format-agent-output.ts
+++ b/packages/local/lib/format-agent-output.ts
@@ -1,0 +1,44 @@
+interface IntermediateStep {
+  action: {
+    tool: string;
+    toolInput: Record<string, unknown>;
+    log: string;
+  };
+  observation: string;
+}
+
+interface AgentResultJsonOutput {
+  output: string;
+  intermediateSteps: IntermediateStep[];
+}
+
+export function formatResultsToMarkdown(result: AgentResultJsonOutput): string {
+  const task =
+    result.intermediateSteps[0]?.action?.log?.split('\n')[0]?.substring(10) ||
+    'Unknown Task';
+
+  const steps = result.intermediateSteps
+    .map((step, index) => {
+      return `### Step ${index + 1}: ${step.action.tool}
+  
+  ${step.action.log}
+  
+  \`\`\`json
+  ${JSON.stringify(step.action.toolInput, null, 2)}
+  \`\`\`
+  
+  **Observation:** ${step.observation}
+  `;
+    })
+    .join('\n\n\n');
+
+  return `# Task: ${task}
+  
+  ${steps}
+  
+  ## Output
+  
+  \`\`\`json
+  ${JSON.stringify(result.output, null, 2)}
+  \`\`\``;
+}


### PR DESCRIPTION
There's a little utility that can take results from the Agent and format them to a Markdown file.

Added a new option to the start script (it defaults to markdown)
```
.option(
    '-of, --outputFormat <format>',
    'Specify the output format json or md',
    'md'
  ) 
```

One question is whether the Agent should be responsible for the formatting, or it's something that happens after the agent returns (e.g. in the local script). My guess is we should move this code to the Agent itself.