### PR TITLE
[oss sprint|part 5] Add markdown result formatter

### DIFF
--- a/packages/core/lib/AgentResult.ts
+++ b/packages/core/lib/AgentResult.ts
@@ -1,0 +1,6 @@
+import type { AgentStep } from 'langchain/schema';
+
+export interface AgentResult {
+  output: string;
+  intermediateSteps: AgentStep[];
+}

--- a/packages/core/lib/HostAgentSession.ts
+++ b/packages/core/lib/HostAgentSession.ts
@@ -9,6 +9,7 @@ import type {
 import WebSocket from 'ws';
 import type { HostMessage } from './HostMessage';
 import { OpenAI } from 'langchain/llms/openai';
+import type { AgentResult } from './AgentResult';
 
 export class HostAgentSession extends EventEmitter {
   socket: WebSocket;
@@ -39,7 +40,7 @@ export class HostAgentSession extends EventEmitter {
     });
   }
 
-  async getResult(): Promise<any> {
+  async getResult(): Promise<AgentResult> {
     return new Promise((resolve, reject) => {
       this.on('complete', (result) => {
         resolve(result);

--- a/packages/core/lib/formats/formatAsMarkdown.ts
+++ b/packages/core/lib/formats/formatAsMarkdown.ts
@@ -1,18 +1,6 @@
-interface IntermediateStep {
-  action: {
-    tool: string;
-    toolInput: Record<string, unknown>;
-    log: string;
-  };
-  observation: string;
-}
+import type { AgentResult } from '../AgentResult';
 
-interface AgentResultJsonOutput {
-  output: string;
-  intermediateSteps: IntermediateStep[];
-}
-
-export function formatResultsToMarkdown(result: AgentResultJsonOutput): string {
+export function formatAsMarkdown(result: AgentResult): string {
   const task =
     result.intermediateSteps[0]?.action?.log?.split('\n')[0]?.substring(10) ||
     'Unknown Task';

--- a/packages/core/lib/index.ts
+++ b/packages/core/lib/index.ts
@@ -9,6 +9,8 @@ import SearchTool from './tools/SearchTool';
 
 export { createAgentServer } from './createAgentServer';
 
+export { formatAsMarkdown } from './formats/formatAsMarkdown';
+
 export {
   DirectoryReadTool,
   FileCreationTool,


### PR DESCRIPTION
# Why

Want to make it easy for people to share results from the OSS `npx` script.

# What

Add @nicolaerusan's markdown formatter, with a bit of cleanup. Will also make the stdout results from the model a lot more readable too, separately from this.

# Test Plan

npx magnet-agent -f ./ --task "Edit the README.md to show how to use npx magnet-agent" -o ./test.md -r -of md