### PR TITLE
[oss sprint|part 6] Make the terminal output actually readable

### DIFF
--- a/packages/local/lib/container.ts
+++ b/packages/local/lib/container.ts
@@ -21,7 +21,7 @@ export function createImage() {
       '..',
       '..'
     )}; docker build -t ${IMAGE_NAME} -f local/Dockerfile .`
-  ).toString();
+  );
 }
 
 export function containerExists() {

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -53,8 +53,10 @@
   },
   "dependencies": {
     "@magnet-agent/core": "link:../core",
+    "chalk": "^4.1.2",
     "commander": "^10.0.1",
     "dockerode": "^3.3.5",
-    "dotenv": "^16.1.4"
+    "dotenv": "^16.1.4",
+    "indent-string": "^4.0.0"
   }
 }

--- a/packages/local/pnpm-lock.yaml
+++ b/packages/local/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@magnet-agent/core':
     specifier: link:../core
     version: link:../core
+  chalk:
+    specifier: ^4.1.2
+    version: 4.1.2
   commander:
     specifier: ^10.0.1
     version: 10.0.1
@@ -17,6 +20,9 @@ dependencies:
   dotenv:
     specifier: ^16.1.4
     version: 16.1.4
+  indent-string:
+    specifier: ^4.0.0
+    version: 4.0.0
 
 devDependencies:
   '@types/dockerode':
@@ -562,7 +568,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -693,7 +698,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -704,11 +708,9 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
@@ -1346,7 +1348,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -1399,6 +1400,11 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
     dev: true
+
+  /indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+    dev: false
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -1957,7 +1963,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}


### PR DESCRIPTION
# Why

We're polishing up the command-line-only version of Magnet Agent for OSS release.

# What

The terminal output is super hard to read. Colorize it an format it with Chalk so that it's readable.

# Test Plan

npx magnet-agent -f ./ --task "Edit the README.md to show how to use npx magnet-agent" -o ./test.md -r -of md

<img width="1022" alt="Screen Shot 2023-06-20 at 1 48 58 PM" src="https://github.com/hey-pal/magnet-agent/assets/44190/298ab5fa-1133-4ad2-b85f-ab493241f75c">
