### PR TITLE
[oss sprint|part 10] Configure OpenAI at the agent session level

### DIFF
--- a/packages/core/lib/Host.ts
+++ b/packages/core/lib/Host.ts
@@ -6,19 +6,10 @@ import { HostAgentSession } from './HostAgentSession';
 export class Host {
   hostname: string;
   port: number;
-  modelName: string;
-  openAIApiKey: string;
 
-  constructor(
-    hostname: string,
-    port: number,
-    modelName: string,
-    openAIApiKey: string
-  ) {
+  constructor(hostname: string, port: number) {
     this.hostname = hostname;
     this.port = port;
-    this.modelName = modelName;
-    this.openAIApiKey = openAIApiKey;
   }
 
   async uploadDirectory(repoName: string, directoryPath: string) {
@@ -33,13 +24,18 @@ export class Host {
     });
   }
 
-  createAgent(repoName: string, taskDescription: string): HostAgentSession {
+  createAgent(
+    repoName: string,
+    taskDescription: string,
+    modelName: string,
+    openAIApiKey: string
+  ): HostAgentSession {
     return new HostAgentSession(
       `ws://${this.hostname}:${this.port}/agent`,
       repoName,
       taskDescription,
-      this.modelName,
-      this.openAIApiKey
+      modelName,
+      openAIApiKey
     );
   }
 }

--- a/packages/local/lib/cmd.ts
+++ b/packages/local/lib/cmd.ts
@@ -94,10 +94,10 @@ async function runAsyncTask() {
 
   logAgent('Running task...');
 
-  const host = new Host(HOST, PORT, modelName, openAIApiKey);
+  const host = new Host(HOST, PORT);
   await host.uploadDirectory(folder, folder);
 
-  const session = host.createAgent(folder, task);
+  const session = host.createAgent(folder, task, modelName, openAIApiKey);
   session.on('action', (action) => {
     logAgent(
       chalk.blue.bold('Performed action...\n\n') +


### PR DESCRIPTION
# Why

Due to architecture of Magnet, we need the OpenAI key to be associated with the `createAgent` method, rather than the `Host` method.

# What

We'll move this down. In a later PR I'll make it so that this can call into the Magnet API for Pro customers.

# Test Plan

`npx magnet-agent`...