### PR TITLE
Add ability for agent to auto-clarify tasks

### DIFF
--- a/magnet-agent/README.md
+++ b/magnet-agent/README.md
@@ -25,6 +25,7 @@ OPENAI_API_KEY=your_openai_api_key_here npx magnet-agent -f ./ -t "Your task her
 - `-f` is the path to the folder you want to run the task on.
 - `-t` is the task description.
 - `-o` is the path to the file where the agent will output the results.
+- `-c` will prompt the agent to clarify the task description before implementing.
 
 You'll need to have [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running on your machine.
 

--- a/magnet-agent/lib/host/Host.ts
+++ b/magnet-agent/lib/host/Host.ts
@@ -2,6 +2,7 @@ import FormData from 'form-data';
 import axios from 'axios';
 import { createDirectorySource } from './createDirectorySource';
 import { HostTask } from './HostTask';
+import type { BaseLLM } from 'langchain/llms/base';
 
 export class Host {
   hostname: string;
@@ -27,15 +28,13 @@ export class Host {
   startTask(
     repoName: string,
     taskDescription: string,
-    modelName: string,
-    openAIApiKey: string
+    model: BaseLLM
   ): HostTask {
     return new HostTask(
       `ws://${this.hostname}:${this.port}/agent`,
       repoName,
       taskDescription,
-      modelName,
-      openAIApiKey
+      model
     );
   }
 }

--- a/magnet-agent/lib/host/HostTask.ts
+++ b/magnet-agent/lib/host/HostTask.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { OpenAI } from 'langchain/llms/openai';
+import type { BaseLLM } from 'langchain/llms/base';
 import WebSocket from 'ws';
 
 import type { HostMessage } from './HostMessage';
@@ -16,20 +16,16 @@ import type { AgentResult } from '../agent/AgentResult';
 export class HostTask extends EventEmitter {
   socket: WebSocket;
 
-  model: OpenAI;
+  model: BaseLLM;
 
   constructor(
     url: string,
     repoName: string,
     taskDescription: string,
-    modelName: string,
-    openAIApiKey: string
+    model: BaseLLM
   ) {
     super();
-    this.model = new OpenAI({
-      modelName,
-      openAIApiKey,
-    });
+    this.model = model;
     this.socket = new WebSocket(url);
     this.socket.on('open', () => {
       this.sendMessage({

--- a/magnet-agent/lib/host/HostTaskClarification.ts
+++ b/magnet-agent/lib/host/HostTaskClarification.ts
@@ -1,0 +1,59 @@
+import type { BaseLLM } from 'langchain/llms/base';
+import { StructuredOutputParser } from 'langchain/output_parsers';
+import { PromptTemplate } from 'langchain/prompts';
+import { z } from 'zod';
+
+export async function createClarifyingQuestions(
+  taskDescription: string,
+  model: BaseLLM
+): Promise<string[]> {
+  const parser = StructuredOutputParser.fromZodSchema(
+    z.object({
+      questions: z
+        .array(z.string())
+        .describe(
+          'questions to the product manager about what they mean by the task description.'
+        ),
+    })
+  );
+  const formatInstructions = parser.getFormatInstructions();
+  const prompt = new PromptTemplate({
+    template:
+      "You're an expert engineer and just received a task from a product manager: '{task_description}'. Ask some clarifying questions about the technical specification of the task so you can write the correct code for it. Don't worry about timing or abstract requirements. Feel free to ask about the code involved. Ask no more than 4 questions, fewer if the task is clear. \n{format_instructions}",
+    inputVariables: ['task_description'],
+    partialVariables: { format_instructions: formatInstructions },
+  });
+
+  const input = await prompt.format({
+    task_description: taskDescription,
+  });
+
+  const response = await model.call(input);
+  const { questions } = await parser.parse(response);
+  return questions;
+}
+
+export async function createClarifiedTaskDescription(
+  taskDescription: string,
+  clarifications: [string, string][],
+  model: BaseLLM
+): Promise<string> {
+  const clarificationsString = clarifications.reduce(
+    (acc, [question, answer]) => `${acc}Q: ${question}\nA: ${answer}\n\n`,
+    ''
+  );
+
+  const prompt = new PromptTemplate({
+    template:
+      "You're an expert engineer and just received a task from a product manager: '{task_description}'. Write an updated task description incorporating the clarifications you received. \n{clarifications}",
+    inputVariables: ['task_description', 'clarifications'],
+  });
+
+  const input = await prompt.format({
+    task_description: taskDescription,
+    clarifications: clarificationsString,
+  });
+
+  const response = await model.call(input);
+  return response;
+}


### PR DESCRIPTION
# Why

gpt-engineer has the ability to auto-clarify task descriptions.

# What

Add the ability to auto-clarify vague task descriptions with the `-c` param.

# Test Plan

npx magnet-agent -f ./ -tf ../TASK.md -o output.md -m gpt-4 -c