### PR TITLE
Make the container API async

### DIFF
--- a/magnet-agent/lib/version.ts
+++ b/magnet-agent/lib/version.ts
@@ -1,0 +1,1 @@
+export const version = '0.1.3';

--- a/magnet-agent/package.json
+++ b/magnet-agent/package.json
@@ -36,7 +36,8 @@
     "clean": "rm -rf dist && node ./scripts/clean-import-stubs.js",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "build": "pnpm clean && tsc --project tsconfig.json && node ./scripts/add-import-stubs.js",
+    "prepublish": "pnpm run build",
+    "build": "pnpm clean && node ./scripts/write-version.js && tsc --project tsconfig.json && node ./scripts/add-import-stubs.js",
     "start": "node ./dist/cli/agentServer.js"
   },
   "dependencies": {

--- a/magnet-agent/scripts/clean-import-stubs.js
+++ b/magnet-agent/scripts/clean-import-stubs.js
@@ -1,4 +1,4 @@
-const { unlink, readdir, rmdir, stat } = require('fs/promises');
+const { unlink, readdir, rmdir } = require('fs/promises');
 const path = require('path');
 
 const { sync: walkSync } = require('walkdir');

--- a/magnet-agent/scripts/write-version.js
+++ b/magnet-agent/scripts/write-version.js
@@ -1,0 +1,10 @@
+const { writeFile } = require('fs/promises');
+const path = require('path');
+
+const { version } = require('../package.json');
+
+(async () => {
+  const versionFile = path.join(__dirname, '..', 'lib', 'version.ts');
+  const versionFileContent = `export const version = '${version}';\n`;
+  await writeFile(versionFile, versionFileContent);
+})();


### PR DESCRIPTION
# Why

For https://github.com/hey-pal/codemagnet/pull/58, the container API is currently sync which can be extremely slowwwwww and hangs the app in some cases.

# What

Make the container API totally async, so we can use it in magnet safely.

Add a write-version.js script so that TypeScript doesn't mess up the directory structure when trying to compile the package.json.

# Test Plan

npx magnet-agent ...