### PR TITLE
Move clarification into the agent itself

### DIFF
--- a/magnet-agent/lib/agent/Agent.ts
+++ b/magnet-agent/lib/agent/Agent.ts
@@ -1,29 +1,32 @@
-import { readFile, readdir } from 'fs/promises';
-import path from 'path';
-
-import { PromptTemplate } from 'langchain';
 import {
   AgentExecutor,
   initializeAgentExecutorWithOptions,
 } from 'langchain/agents';
 import { CallbackManager } from 'langchain/callbacks';
-import { StructuredOutputParser } from 'langchain/output_parsers';
 import { v4 as uuid } from 'uuid';
-import { z } from 'zod';
 
 import { AgentCallbackHandler } from './AgentCallbackHandler';
 import type { AgentContext } from './AgentContext';
 import type { AgentMessage } from './AgentMessage';
 import { AgentModel } from './AgentModel';
 import type { AgentRepos } from './AgentRepos';
-import type { AgentRequest, AgentRequestResponse } from './AgentRequest';
+import type {
+  AgentRequest,
+  AgentRequestResponse,
+  AgentAskHumanRequest,
+  AgentRequestAskHumanResponse,
+} from './AgentRequest';
 import type { AgentStructuredTool } from './AgentStructuredTool';
 import type {
   HostMessage,
   HostResponseMessage,
   HostStartMessage,
 } from '../host/HostMessage';
-
+import {
+  createTaskAgentInput,
+  createTaskClarifyingQuestions,
+  createClarifiedTask,
+} from './AgentTasks';
 export class Agent {
   repos: AgentRepos;
 
@@ -70,63 +73,56 @@ export class Agent {
       throw new Error('Agent is already running');
     }
 
-    const { repoName, taskDescription } = message;
+    const {
+      repoName,
+      taskDescription: initialTaskDescription,
+      clarify,
+    } = message;
     const workspaceDir = await this.repos.createWorkspace(repoName);
     const context: AgentContext = {
       sendRequest: (request) => this.sendRequest(request),
     };
     const tools = this.tools.map((tool) => new (tool as any)(context));
+    const model = new AgentModel({ context });
 
-    const [executor, files] = await Promise.all([
-      initializeAgentExecutorWithOptions(tools, new AgentModel({ context }), {
+    let taskDescription = initialTaskDescription;
+    if (clarify) {
+      const questions = await createTaskClarifyingQuestions(
+        initialTaskDescription,
+        model
+      );
+      let clarifications: [string, string][] = [];
+      for (const question of questions) {
+        const answer = await this.sendRequest<
+          AgentAskHumanRequest,
+          AgentRequestAskHumanResponse
+        >({
+          type: 'ask_human',
+          question,
+        });
+        clarifications.push([question, answer]);
+      }
+      taskDescription = await createClarifiedTask(
+        initialTaskDescription,
+        clarifications,
+        model
+      );
+    }
+
+    const [executor, input] = await Promise.all([
+      initializeAgentExecutorWithOptions(tools, model, {
         agentType: 'structured-chat-zero-shot-react-description',
         returnIntermediateSteps: true,
         verbose: true,
       }),
-      readdir(workspaceDir),
+      createTaskAgentInput(workspaceDir, taskDescription),
     ]);
     this.executor = executor;
-
-    const readmePath = files.filter((file) =>
-      ['README.md', 'README.txt', 'README'].includes(file)
-    )[0];
-    const readme = readmePath
-      ? await readFile(path.join(workspaceDir, readmePath), 'utf-8')
-      : null;
 
     const callbacks = new CallbackManager();
     callbacks.addHandler(
       new AgentCallbackHandler((...args) => this.sendMessage(...args))
     );
-
-    const parser = StructuredOutputParser.fromZodSchema(
-      z.object({
-        explanation: z
-          .string()
-          .describe(
-            'A description of the code change made, an answer to the question in the task, or explanation of why the agent gave up.'
-          ),
-      })
-    );
-    const formatInstructions = parser.getFormatInstructions();
-    const prompt = new PromptTemplate({
-      template:
-        "You're an expert engineer. The codebase you're working with is located in the {workspace_dir} directory. I'm the product manager and need you to implement this task: '{task_description}'. Here's a listing of the first 50 files in the {workspace_dir} directory: {files}. Explore the codebase, and based on what you understand, complete the task. If the task is unclear, you can ask me via AskHumanTool. {readme} \n{format_instructions}",
-      inputVariables: ['task_description', 'workspace_dir', 'files', 'readme'],
-      partialVariables: { format_instructions: formatInstructions },
-    });
-
-    const input = await prompt.format({
-      task_description: taskDescription,
-      workspace_dir: workspaceDir,
-      files: JSON.stringify(files.slice(0, 50)),
-      readme: readme
-        ? `Here's an excerpt of the README:\n"""\n${readme.slice(
-            0,
-            1000
-          )}\n"""\n`
-        : '',
-    });
 
     try {
       const chain = await this.executor.call({ input }, callbacks);
@@ -170,7 +166,6 @@ export class Agent {
         reject,
       };
     });
-    console.log(request);
     this.sendMessage({
       type: 'request',
       requestId,

--- a/magnet-agent/lib/agent/AgentMessage.ts
+++ b/magnet-agent/lib/agent/AgentMessage.ts
@@ -8,6 +8,11 @@ export type AgentRequestMessage = {
   request: AgentRequest;
 };
 
+export type AgentUpdateTaskMessage = {
+  type: 'update-task';
+  taskDescription: string;
+};
+
 export type AgentActionMessage = {
   type: 'action';
   action: AgentAction;
@@ -25,6 +30,7 @@ export type AgentCompleteMessage = {
 
 export type AgentMessage =
   | AgentRequestMessage
+  | AgentUpdateTaskMessage
   | AgentActionMessage
   | AgentErrorMessage
   | AgentCompleteMessage;

--- a/magnet-agent/lib/agent/AgentTasks.ts
+++ b/magnet-agent/lib/agent/AgentTasks.ts
@@ -1,9 +1,12 @@
+import { readFile, readdir } from 'fs/promises';
+import path from 'path';
+
 import type { BaseLLM } from 'langchain/llms/base';
 import { StructuredOutputParser } from 'langchain/output_parsers';
 import { PromptTemplate } from 'langchain/prompts';
 import { z } from 'zod';
 
-export async function createClarifyingQuestions(
+export async function createTaskClarifyingQuestions(
   taskDescription: string,
   model: BaseLLM
 ): Promise<string[]> {
@@ -33,7 +36,7 @@ export async function createClarifyingQuestions(
   return questions;
 }
 
-export async function createClarifiedTaskDescription(
+export async function createClarifiedTask(
   taskDescription: string,
   clarifications: [string, string][],
   model: BaseLLM
@@ -56,4 +59,44 @@ export async function createClarifiedTaskDescription(
 
   const response = await model.call(input);
   return response;
+}
+
+export async function createTaskAgentInput(
+  workspaceDir: string,
+  taskDescription: string
+) {
+  const files = await readdir(workspaceDir);
+  const readmePath = files.filter((file) =>
+    ['README.md', 'README.txt', 'README'].includes(file)
+  )[0];
+  const readme = readmePath
+    ? await readFile(path.join(workspaceDir, readmePath), 'utf-8')
+    : null;
+  const parser = StructuredOutputParser.fromZodSchema(
+    z.object({
+      explanation: z
+        .string()
+        .describe(
+          'A description of the code change made, an answer to the question in the task, or explanation of why the agent gave up.'
+        ),
+    })
+  );
+  const formatInstructions = parser.getFormatInstructions();
+  const prompt = new PromptTemplate({
+    template:
+      "You're an expert engineer. The codebase you're working with is located in the {workspace_dir} directory. I'm the product manager and need you to implement this task: '{task_description}'. Here's a listing of the first 50 files in the {workspace_dir} directory: {files}. Explore the codebase, and based on what you understand, complete the task. If the task is unclear, you can ask me via AskHumanTool. {readme} \n{format_instructions}",
+    inputVariables: ['task_description', 'workspace_dir', 'files', 'readme'],
+    partialVariables: { format_instructions: formatInstructions },
+  });
+
+  const input = await prompt.format({
+    task_description: taskDescription,
+    workspace_dir: workspaceDir,
+    files: JSON.stringify(files.slice(0, 50)),
+    readme: readme
+      ? `Here's an excerpt of the README:\n"""\n${readme.slice(0, 1000)}\n"""\n`
+      : '',
+  });
+
+  return input;
 }

--- a/magnet-agent/lib/host/Host.ts
+++ b/magnet-agent/lib/host/Host.ts
@@ -31,14 +31,16 @@ export class Host {
     repoName: string,
     taskDescription: string,
     model: BaseLLM,
-    handleAskHuman: (question: string) => Promise<string>
+    handleAskHuman: (question: string) => Promise<string>,
+    clarify: boolean = false
   ): HostTask {
     return new HostTask(
       `ws://${this.hostname}:${this.port}/agent`,
       repoName,
       taskDescription,
       model,
-      handleAskHuman
+      handleAskHuman,
+      clarify
     );
   }
 }

--- a/magnet-agent/lib/host/HostMessage.ts
+++ b/magnet-agent/lib/host/HostMessage.ts
@@ -8,6 +8,7 @@ export type HostStartMessage = {
   type: 'start';
   repoName: string;
   taskDescription: string;
+  clarify: boolean;
 };
 
 export type HostResponseMessage = {

--- a/magnet-agent/lib/host/HostTask.ts
+++ b/magnet-agent/lib/host/HostTask.ts
@@ -25,7 +25,8 @@ export class HostTask extends EventEmitter {
     repoName: string,
     taskDescription: string,
     model: BaseLLM,
-    handleAskHuman: (question: string) => Promise<string>
+    handleAskHuman: (question: string) => Promise<string>,
+    clarify: boolean = false
   ) {
     super();
     this.model = model;
@@ -36,6 +37,7 @@ export class HostTask extends EventEmitter {
         type: 'start',
         repoName,
         taskDescription,
+        clarify,
       });
     });
     this.socket.on('message', (message: string) => {

--- a/magnet-agent/lib/host/index.ts
+++ b/magnet-agent/lib/host/index.ts
@@ -1,5 +1,4 @@
 export { Host } from './Host';
-export * from './HostTaskClarification';
 
 export { createDirectorySource } from './createDirectorySource';
 

--- a/magnet-agent/lib/version.ts
+++ b/magnet-agent/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = 'cee7fd3';
+export const version = 'c5a07e7';


### PR DESCRIPTION
# Why
There's a neat clarification feature and we want to add it to the UI in Magnet. Key problem is that we need to maintain a state machine somewhere of whether the agent is clarifying, running, etc.

We added this state machine to the CLI originally, but it's super messy to try to add to the UI the same way.

# What

Move the state machine into the agent, and simplify both the CLI and the UI considerably.

# Test Plan

Verify that clarifying works, and that it's disabled if you say "no" to clarifications:
<img width="1308" alt="Screen Shot 2023-06-28 at 3 15 12 PM" src="https://github.com/hey-pal/magnet-agent/assets/44190/ea2ea214-aef9-4b83-99de-f2c7223b0b4b">

