### PR TITLE
Fix crash

### DIFF
--- a/magnet-agent/lib/agent/AgentTasks.ts
+++ b/magnet-agent/lib/agent/AgentTasks.ts
@@ -84,7 +84,7 @@ export async function createTaskAgentInput(
   const formatInstructions = parser.getFormatInstructions();
   const prompt = new PromptTemplate({
     template:
-      "You're an expert engineer. The codebase you're working with is located in the {workspace_dir} directory. I'm the product manager and need you to implement this task: '{task_description}'. Here's a listing of the first 50 files in the {workspace_dir} directory: {files}. Explore the codebase, and based on what you understand, complete the task. If the task is unclear, you can ask me via AskHumanTool. {readme} \n{format_instructions}",
+      "You're an expert engineer. The codebase you're working with is located in the {workspace_dir} directory. I'm the product manager and need you to implement this task: '{task_description}'. Here's a listing of the first 10 files in the {workspace_dir} directory: {files}. Explore the codebase, and based on what you understand, complete the task. If the task is unclear, you can ask me via AskHumanTool. {readme} \n{format_instructions}",
     inputVariables: ['task_description', 'workspace_dir', 'files', 'readme'],
     partialVariables: { format_instructions: formatInstructions },
   });
@@ -92,9 +92,9 @@ export async function createTaskAgentInput(
   const input = await prompt.format({
     task_description: taskDescription,
     workspace_dir: workspaceDir,
-    files: JSON.stringify(files.slice(0, 50)),
+    files: JSON.stringify(files.slice(0, 10)),
     readme: readme
-      ? `Here's an excerpt of the README:\n"""\n${readme.slice(0, 1000)}\n"""\n`
+      ? `Here's an excerpt of the README:\n"""\n${readme.slice(0, 500)}\n"""\n`
       : '',
   });
 

--- a/magnet-agent/lib/agent/createAgentServer.ts
+++ b/magnet-agent/lib/agent/createAgentServer.ts
@@ -15,7 +15,11 @@ export function createAgentServer(config: ServerConfig) {
 
   const server = fastify();
 
-  server.register(fastifyMulitpartPlugin);
+  server.register(fastifyMulitpartPlugin, {
+    limits: {
+      fileSize: 1024 ** 3,
+    },
+  });
   server.register(fastifyWebsocketPlugin);
 
   server.post('/upload', async (request, reply) => {
@@ -45,7 +49,6 @@ export function createAgentServer(config: ServerConfig) {
       });
 
       connection.socket.on('message', (rawMessage: any) => {
-        console.log('received message', rawMessage.toString());
         const message = JSON.parse(rawMessage.toString());
         agent.handleMessage(message);
       });

--- a/magnet-agent/lib/version.ts
+++ b/magnet-agent/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = 'f4f70b7';
+export const version = '077c207';


### PR DESCRIPTION
# Why

The crash Nicolae was seeing earlier was due to a combination of factors:
1. fastify has a max upload size that's very small (1MB)
2. the archive is sometimes corrupted for large directories

# What

So:
1. increase the limit to 1GB
2. don't package .git
3. use the stream to determine when the archive is done (https://github.com/archiverjs/node-archiver/issues/476)

# Test Plan

Run magnet on a big directory, with .git included