### PR TITLE
Add step to open results for review before deciding to apply or not

### DIFF
--- a/magnet-agent/README.md
+++ b/magnet-agent/README.md
@@ -36,6 +36,10 @@ See [Documentation](https://toolkitai.notion.site/Magnet-Docs-55cd2321039443d695
 
 See [Contributing](https://toolkitai.notion.site/Contributing-d6ff3008d5664da8ba3cd59efe1f5511?pvs=4).
 
+## Telemetry
+
+See [Telemetry](./TELEMETRY.md) for details on how we collect telemetry data, and how to opt out if desired.
+
 ## License
 
 [Apache 2.0](./LICENSE)

--- a/magnet-agent/TELEMETRY.md
+++ b/magnet-agent/TELEMETRY.md
@@ -1,0 +1,23 @@
+# Telemetry in Magnet Agent
+
+Telemetry is a crucial part of the Magnet Agent. It allows us to understand how the agent is used, identify issues and areas for improvement, and ensure the best possible user experience. The data we collect includes performance metrics, errors, and usage patterns.
+
+Here's a table of the events that we send with `sendEvent`:
+
+| Event                        | Description                                      |
+| ---------------------------- | ------------------------------------------------ |
+| start                        | The agent has started                            |
+| docker_desktop_not_installed | Docker Desktop is not installed                  |
+| performance                  | Performance metrics for various operations       |
+| interrupt                    | The agent was interrupted                        |
+| complete                     | The agent has completed its task                 |
+| error                        | An error occurred                                |
+| review_agent_result          | The user reviewed the agent's result             |
+| apply_agent_result           | The user applied the agent's result              |
+| agent_result_feedback        | The user provided feedback on the agent's result |
+
+Each event contains additional properties that provide more context about the event.
+
+## Opting Out of Telemetry
+
+If you prefer not to send telemetry data, you can opt out by setting the `MAGNET_AGENT_TELEMETRY` environment variable. Please note that this may limit our ability to improve the agent and provide support.

--- a/magnet-agent/lib/host/HostTelemetry.ts
+++ b/magnet-agent/lib/host/HostTelemetry.ts
@@ -20,7 +20,7 @@ const client = analyticsDisabled
       host: 'https://app.posthog.com',
     });
 
-function sendEvent(event: string, properties: any) {
+function sendEvent(event: string, properties: Record<string, any> = {}) {
   client.capture({
     distinctId,
     event,
@@ -60,6 +60,14 @@ export function sendError(error: any) {
   sendEvent('error', {
     error: error instanceof Error ? error.message : String(error),
   });
+}
+
+export function sendReviewAgentResult(option: string) {
+  sendEvent('review_agent_result', { option });
+}
+
+export function sendApplyAgentResult() {
+  sendEvent('apply_agent_result');
 }
 
 export function sendAgentResultFeedback(

--- a/magnet-agent/lib/util/openFile.ts
+++ b/magnet-agent/lib/util/openFile.ts
@@ -1,0 +1,29 @@
+import { exec as callbackExec } from 'child_process';
+import { platform } from 'os';
+import { promisify } from 'util';
+
+const exec = promisify(callbackExec);
+
+export async function openFile(filePath: string): Promise<void> {
+  let command: string;
+
+  switch (platform()) {
+    case 'darwin': // Mac OS
+      command = `open ${filePath}`;
+      break;
+    case 'win32': // Windows
+      command = `start ${filePath}`;
+      break;
+    case 'linux': // Linux
+      command = `xdg-open ${filePath}`;
+      break;
+    default:
+      throw new Error(`Unsupported platform: ${platform()}`);
+  }
+
+  try {
+    await exec(command);
+  } catch (error) {
+    throw new Error(`Failed to open file: ${(error as Error).message}`);
+  }
+}

--- a/magnet-agent/lib/version.ts
+++ b/magnet-agent/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = '737958d';
+export const version = '7b8a120';

--- a/magnet-agent/package.json
+++ b/magnet-agent/package.json
@@ -29,6 +29,7 @@
     "containers/local.d.ts",
     "Dockerfile",
     "README.md",
+    "TELEMETRY.md",
     "LICENSE",
     "package.json"
   ],


### PR DESCRIPTION
# Background

Currently at the end of the Magnet Agent workflow, there's no way to review results.

# This PR

Add an easy way to review results:
- switch outfile to outfolder so we can output both results.md and patch.diff
- write patch.diff
- add openFile command and open the file

And while we're here use Magnet Agent to generate a TELEMETRY.md as the test plan and also a useful piece of documentation.

# Test Plan

https://www.loom.com/share/35df94933503420281b2653b2c0badb2