### PR TITLE
Add support for GitHub repo URLs

### DIFF
--- a/ai-dev/lib/agent/AgentRepos.ts
+++ b/ai-dev/lib/agent/AgentRepos.ts
@@ -30,10 +30,10 @@ export class AgentRepos {
     await decompress(repoPath, workspaceDir);
     await exec(
       `
-        git init &&
         git config --global init.defaultBranch main &&
         git config --global user.email ai-dev-no-reply@toolkit.ai &&
         git config --global user.name "AI Dev" &&
+        git init &&
         git add . && 
         git commit -m "Initial commit"
       `,

--- a/ai-dev/lib/host/Host.ts
+++ b/ai-dev/lib/host/Host.ts
@@ -3,7 +3,6 @@ import FormData from 'form-data';
 import type { ChatOpenAI } from 'langchain/chat_models/openai';
 
 import { HostTask } from './HostTask.js';
-import { createDirectorySource } from './createDirectorySource.js';
 
 export class Host {
   hostname: string;
@@ -15,10 +14,10 @@ export class Host {
     this.port = port;
   }
 
-  async uploadDirectory(repoName: string, directoryPath: string) {
+  async uploadSource(repoName: string, stream: NodeJS.ReadableStream) {
     const form = new FormData();
     form.append('repoName', repoName);
-    form.append('archive', await createDirectorySource(directoryPath));
+    form.append('archive', stream);
 
     await axios.post(`http://${this.hostname}:${this.port}/upload`, form, {
       headers: {

--- a/ai-dev/lib/host/index.ts
+++ b/ai-dev/lib/host/index.ts
@@ -1,6 +1,7 @@
 export { Host } from './Host.js';
 
-export { createDirectorySource } from './createDirectorySource.js';
+export { createDirectorySource } from './source/createDirectorySource.js';
+export { createGitHubSource } from './source/createGitHubSource.js';
 
 export { formatAgentResult } from './result/formatAgentResult.js';
 export { formatAgentResultOutput } from './result/formatAgentResultOutput.js';

--- a/ai-dev/lib/host/source/createDirectorySource.ts
+++ b/ai-dev/lib/host/source/createDirectorySource.ts
@@ -26,7 +26,9 @@ function findGitignore(currentDir: string): string | null {
   return findGitignore(parentDir);
 }
 
-export async function createDirectorySource(directoryPath: string) {
+export async function createDirectorySource(
+  directoryPath: string
+): Promise<NodeJS.ReadableStream> {
   const resolved = path.resolve(directoryPath);
   const gitignorePath = findGitignore(resolved);
   const gitignoreList = gitignorePath

--- a/ai-dev/lib/host/source/createGitHubSource.ts
+++ b/ai-dev/lib/host/source/createGitHubSource.ts
@@ -1,0 +1,20 @@
+import { exec as execCallback } from 'child_process';
+import { createReadStream } from 'fs';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+
+const exec = promisify(execCallback);
+
+export async function createGitHubSource(
+  owner: string,
+  repo: string,
+  branch: string
+): Promise<NodeJS.ReadableStream> {
+  const tmpdir = await fs.mkdtemp(path.join(os.tmpdir(), 'repo-'));
+  await exec(
+    `curl -L https://github.com/${owner}/${repo}/archive/refs/heads/${branch}.zip -o ${tmpdir}/repo.zip -f`
+  );
+  return createReadStream(path.join(tmpdir, 'repo.zip'));
+}

--- a/ai-dev/lib/version.ts
+++ b/ai-dev/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = 'fb9ee8b';
+export const version = 'f1c1ff9';


### PR DESCRIPTION
# Background

We want to gradually add support for GitHub repo URLs. 

# This PR

Adding a directory source demo to show how this is possible. Essentially download the zipball and pass it into the agent for projects.

# Test Plan
<img width="847" alt="Screen Shot 2023-07-27 at 6 08 28 PM" src="https://github.com/hey-pal/ai-dev/assets/44190/bd84c5ce-3e31-474f-bde0-6d36d59ce73d">
<img width="915" alt="Screen Shot 2023-07-27 at 6 08 35 PM" src="https://github.com/hey-pal/ai-dev/assets/44190/7a0c7f02-78ec-47c3-855b-485c8a9821a8">
